### PR TITLE
Add pre-shared key authentication on the POST endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,17 @@ the `name` and `success` properties. For example:
 }
 ```
 
+When authentication is enabled, you must also pass in the header
+`Authorization: PRPC <pre-shared key>` (excluding the `<` and `>`).
+
 ## Configuration
 
 The path to the SQLite database is configured by the `PRPC_DB_PATH`
 environment variable. This defaults to `prpc.db` in the current directory of
 execution.
+
+To enable authentication based on a pre-shared key, you may set the `PRPC_PSK` environment
+variable with the desired pre-shared key.
 
 ## Dependency Management
 

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ deps =
 commands =
     flake8
 
-[testenv:py]
+[testenv:py3]
 description = Python 3 unit tests [Mandatory]
 commands =
     {[testenv]pytest_command}


### PR DESCRIPTION
This is useful if you want to ensure some level of data integrity when the app isn't behind a very tight firewall.