### PR TITLE
Pass the Authorization header from httpd to Flask

### DIFF
--- a/docker/httpd.conf
+++ b/docker/httpd.conf
@@ -15,6 +15,7 @@ WSGISocketPrefix /tmp/wsgi
 WSGIDaemonProcess prpc threads=5 home=/tmp
 WSGIScriptAlias / /src/prpc/wsgi.py
 WSGICallableObject app
+WSGIPassAuthorization on
 
 <Directory /src>
     AllowOverride None


### PR DESCRIPTION
This is required for PSK auth to work in the app.