### PR TITLE
Remove unnecessary equals sign in the metrics output

### DIFF
--- a/prpc/app.py
+++ b/prpc/app.py
@@ -60,7 +60,7 @@ def metrics():
             f"""\
             # HELP {name}_pipeline_run_total The total number of {name} pipeline runs.
             # TYPE {name}_pipeline_run_total counter
-            {name}_pipeline_run_total{{status="success"}} = {pipline_runs["success"]}
+            {name}_pipeline_run_total{{status="success"}} {pipline_runs["success"]}
             {name}_pipeline_run_total{{status="failure"}} {pipline_runs["failure"]}
             """
         )

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -20,11 +20,11 @@ def test_get_metrics(client, db):
         """\
         # HELP car_factory_pipeline_run_total The total number of car_factory pipeline runs.
         # TYPE car_factory_pipeline_run_total counter
-        car_factory_pipeline_run_total{status="success"} = 1
+        car_factory_pipeline_run_total{status="success"} 1
         car_factory_pipeline_run_total{status="failure"} 1
         # HELP truck_factory_pipeline_run_total The total number of truck_factory pipeline runs.
         # TYPE truck_factory_pipeline_run_total counter
-        truck_factory_pipeline_run_total{status="success"} = 2
+        truck_factory_pipeline_run_total{status="success"} 2
         truck_factory_pipeline_run_total{status="failure"} 0
         """
     )


### PR DESCRIPTION
This was added by mistake in a previous commit.